### PR TITLE
Add/reference

### DIFF
--- a/lib/fields/baseField.classFactory.js
+++ b/lib/fields/baseField.classFactory.js
@@ -21,6 +21,16 @@ const FIELDS_OPERATIONS = [
  */
 // eslint-disable-next-line no-unused-vars,require-jsdoc
 const injectIlorm = ilorm => {
+  let fieldBindWithModel = null;
+
+  /**
+   * Internal which resolve when the model is bound with the field.
+   * @type {Promise} Resolve when the field is bound with a model
+   */
+  const assertBindWithModel = new Promise(resolve => {
+    fieldBindWithModel = resolve;
+  });
+
   /**
    * Class representing a field of the schema
    */
@@ -116,6 +126,36 @@ const injectIlorm = ilorm => {
     }
 
     /**
+     * Use to declare a reference between this field (and the current Model) and another Model.field
+     * @param {Model} referencedModel The model this field refer to
+     * @param {Field} referencedField The field (in the referencedModel) this field refer to
+     * @return {BaseField}
+     * @returns {Field} Return the current field (to chainable definition)
+     */
+    reference(referencedModel, referencedField) {
+      // Context async; the reference is declare and non blocking;
+      (new Promise(async (resolve, reject) => {
+        // Avoid unhandled rejection at process level;
+        try {
+          // Wait for current Model to be bound with the field;
+          await assertBindWithModel();
+
+          ilorm.Relation.declareRelation({
+            modelSource: this[BOUND_MODEL],
+            attributeSource: this[NAME],
+            modelReference: referencedModel,
+            attributeReference: referencedField,
+          });
+        } catch (err) {
+          reject(err);
+        }
+      }))
+        .catch(err => ilorm.events.emit('error', err));
+
+      return this;
+    }
+
+    /**
      * Calling at schema binding with model.
      * Could be use to implement specific link between Model class and Field.
      * @param {Model} The model associate with the given field
@@ -123,6 +163,7 @@ const injectIlorm = ilorm => {
      */
     bindWithModel({ InternalModel, }) {
       this[BOUND_MODEL] = InternalModel;
+      fieldBindWithModel();
     }
 
     /**

--- a/lib/fields/baseField.classFactory.js
+++ b/lib/fields/baseField.classFactory.js
@@ -27,7 +27,7 @@ const injectIlorm = ilorm => {
    * Internal which resolve when the model is bound with the field.
    * @type {Promise} Resolve when the field is bound with a model
    */
-  const assertBindWithModel = new Promise(resolve => {
+  const waitForModelBound = new Promise(resolve => {
     fieldBindWithModel = resolve;
   });
 
@@ -139,14 +139,14 @@ const injectIlorm = ilorm => {
         // Avoid unhandled rejection at process level;
         try {
           // Wait for current Model to be bound with the field;
-          await assertBindWithModel();
+          await waitForModelBound();
 
           ilorm.Relation.declareRelation({
             modelSource: this[BOUND_MODEL],
             attributeSource: this[NAME],
-            modelReference: referencedModel === 'string' ?
+            modelReferenced: referencedModel === 'string' ?
               await ilorm.getModelByName(referencedModel) : referencedModel,
-            attributeReference: referencedField,
+            attributeReferenced: referencedField,
           });
         } catch (err) {
           reject(err);

--- a/lib/fields/baseField.classFactory.js
+++ b/lib/fields/baseField.classFactory.js
@@ -127,7 +127,8 @@ const injectIlorm = ilorm => {
 
     /**
      * Use to declare a reference between this field (and the current Model) and another Model.field
-     * @param {Model} referencedModel The model this field refer to
+     * @param {String|Model} referencedModel The model this field refer to
+     * (could be the name of the model as a string or the model itself).
      * @param {Field} referencedField The field (in the referencedModel) this field refer to
      * @return {BaseField}
      * @returns {Field} Return the current field (to chainable definition)
@@ -143,7 +144,8 @@ const injectIlorm = ilorm => {
           ilorm.Relation.declareRelation({
             modelSource: this[BOUND_MODEL],
             attributeSource: this[NAME],
-            modelReference: referencedModel,
+            modelReference: referencedModel === 'string' ?
+              await ilorm.getModelByName(referencedModel) : referencedModel,
             attributeReference: referencedField,
           });
         } catch (err) {

--- a/lib/ilorm.class.js
+++ b/lib/ilorm.class.js
@@ -12,6 +12,8 @@ const {
   stringFieldFactory,
 } = require('./fields');
 
+const relationFactory = require('./model/relation.classFactory');
+
 /**
  * Class representing the full library
  */
@@ -37,7 +39,12 @@ class Ilorm {
      */
     this.modelsRelationsIndex = new Map();
 
-    // Base Class used by the framework:
+    // Internal for Relation management;
+    this.Relation = relationFactory(this);
+
+    /**
+     * Base Class used by the framework:
+     */
     this.BaseModel = baseModelClassFactory(this);
     this.BaseQuery = baseQueryClassFactory(this);
     this.BaseField = baseFieldFactory(this);

--- a/lib/model/relation.classFactory.js
+++ b/lib/model/relation.classFactory.js
@@ -94,16 +94,17 @@ const injectIlorm = ilorm => {
      * @param {String} modelSource The model which reference another model
      * @param {String|Symbol} attributeSource The field of modelSource used to reference modelReference
      * @param {String} modelReference The model to use as referenced
+     * @param {String|Symbol} attributeReference The field of modelSource used to reference modelReference
      * @return {void} Return nothing
      */
-    static declareRelation({ modelSource, attributeSource, modelReference, }) {
+    static declareRelation({ modelSource, attributeSource, modelReference, attributeReference, }) {
       const linearRelation = [
         {
           model: modelSource,
           attribute: attributeSource,
         }, {
           model: modelReference,
-          attribute: modelReference,
+          attribute: attributeReference,
         },
       ].sort((mA, mB) => (
         mA.model.getName() - mB.model.getName()

--- a/lib/model/relation.classFactory.js
+++ b/lib/model/relation.classFactory.js
@@ -92,19 +92,19 @@ const injectIlorm = ilorm => {
     /**
      * Declare a relation between two items
      * @param {String} modelSource The model which reference another model
-     * @param {String|Symbol} attributeSource The field of modelSource used to reference modelReference
-     * @param {String} modelReference The model to use as referenced
-     * @param {String|Symbol} attributeReference The field of modelSource used to reference modelReference
+     * @param {String|Symbol} attributeSource The field of modelSource used to reference modelReferenced
+     * @param {String} modelReferenced The model to use as referenced
+     * @param {String|Symbol} attributeReferenced The field of modelSource used to reference modelReferenced
      * @return {void} Return nothing
      */
-    static declareRelation({ modelSource, attributeSource, modelReference, attributeReference, }) {
+    static declareRelation({ modelSource, attributeSource, modelReferenced, attributeReferenced, }) {
       const linearRelation = [
         {
           model: modelSource,
           attribute: attributeSource,
         }, {
-          model: modelReference,
-          attribute: attributeReference,
+          model: modelReferenced,
+          attribute: attributeReferenced,
         },
       ].sort((mA, mB) => (
         mA.model.getName() - mB.model.getName()
@@ -126,19 +126,21 @@ const injectIlorm = ilorm => {
      * Get relation between two models. The parameters are Model name and not model.
      *
      * @param {String} modelSource Model source name
-     * @param {String} modelReference Model which be referenced (model name)
+     * @param {String} modelReferenced Model which be referenced (model name)
      * @returns {Relation} Return an object explaining the relation between the two models
      */
-    static getRelation({ modelSource, modelReference, }) {
+    static getRelation({ modelSource, modelReferenced, }) {
       if (!references.has(modelSource)) {
-        throw new Error(`${modelSource} does not exists in references map. Could not be linked with ${modelReference}`);
+        throw new Error(
+          `${modelSource} does not exists in references map. Could not be linked with ${modelReferenced}`
+        );
       }
 
-      if (!references.get(modelSource).has(modelReference)) {
-        throw new Error(`${modelSource} does not reference ${modelReference}`);
+      if (!references.get(modelSource).has(modelReferenced)) {
+        throw new Error(`${modelSource} does not reference ${modelReferenced}`);
       }
 
-      return references.get(modelSource).get(modelReference);
+      return references.get(modelSource).get(modelReferenced);
     }
   }
 

--- a/lib/model/relation.classFactory.js
+++ b/lib/model/relation.classFactory.js
@@ -30,8 +30,8 @@ const injectIlorm = ilorm => {
   /**
    * Fetch or insert a relation between two model (create it if not exists).
    * This method is used as helper to the main function "declareRelation"
-   * @param {String} modelA The model to use as reference
-   * @param {String} modelB The model to use as referenced
+   * @param {Model} modelA The model to use as reference
+   * @param {Model} modelB The model to use as referenced
    * @returns {Relation} Return relation
    */
   const fetchOrInsertRelation = ({ modelA, modelB, Relation, }) => {
@@ -132,12 +132,13 @@ const injectIlorm = ilorm => {
     static getRelation({ modelSource, modelReferenced, }) {
       if (!references.has(modelSource)) {
         throw new Error(
-          `${modelSource} does not exists in references map. Could not be linked with ${modelReferenced}`
+          `${modelSource.getName()} does not exists in references map.` +
+          ` Could not be linked with ${modelReferenced.getName()}`
         );
       }
 
       if (!references.get(modelSource).has(modelReferenced)) {
-        throw new Error(`${modelSource} does not reference ${modelReferenced}`);
+        throw new Error(`${modelSource.getName()} does not reference ${modelReferenced.getName()}`);
       }
 
       return references.get(modelSource).get(modelReferenced);

--- a/lib/model/relation.classFactory.js
+++ b/lib/model/relation.classFactory.js
@@ -28,28 +28,36 @@ const injectIlorm = ilorm => {
   const { modelsRelationsIndex: references, } = ilorm;
 
   /**
-   * Save a relation between two model.
+   * Fetch or insert a relation between two model (create it if not exists).
    * This method is used as helper to the main function "declareRelation"
    * @param {String} modelA The model to use as reference
-   * @param {String|Symbol} referenceA The field used to modelA side to reference modelB
    * @param {String} modelB The model to use as referenced
-   * @param {String|Symbol} referenceB The field used to modelB side to reference modelA
-   * @param {Relation} Relation The relation class to instantiate
-   * @returns {void} Return nothing
+   * @returns {Relation} Return relation
    */
-  const declareRelationSide = ({ modelA, referenceA, modelB, referenceB, Relation, }) => {
+  const fetchOrInsertRelation = ({ modelA, modelB, Relation, }) => {
     if (!references.has(modelA)) {
       references.set(modelA, new Map());
     }
+    if (!references.has(modelB)) {
+      references.set(modelB, new Map());
+    }
 
-    // Store in the map :
-    // Map<modelAName, Map<modelBName, { fieldReferenceA, fieldReferenceB }>>
-    references.get(modelA).set(modelB, new Relation({
+    // Does not insert relation twice
+    if (references.get(modelA).has(modelB)) {
+      return references.get(modelA).get(modelB);
+    }
+
+    const relation = new Relation({
       modelA,
       modelB,
-      referenceA,
-      referenceB,
-    }));
+    });
+
+    // Store in the map :
+    // Map<modelAName, Map<modelBName, Relation>>
+    references.get(modelA).set(modelB, relation);
+    references.get(modelB).set(modelA, relation);
+
+    return relation;
   };
 
 
@@ -60,15 +68,25 @@ const injectIlorm = ilorm => {
     /**
      * Create a new relation between two model
      * @param {String} modelA The model to use as reference
-     * @param {String|Symbol} referenceA The field used to modelA side to reference modelB
      * @param {String} modelB The model to use as referenced
-     * @param {String|Symbol} referenceB The field used to modelB side to reference modelA
      */
-    constructor({ modelA, referenceA, modelB, referenceB, }) {
+    constructor({ modelA, modelB, }) {
       this.modelA = modelA;
       this.modelB = modelB;
-      this.referenceA = referenceA;
-      this.referenceB = referenceB;
+      this.references = [];
+    }
+
+    /**
+     * Add a reference tuple to the relation
+     * @param {String|Symbol} referenceA The field used to modelA side to reference modelB
+     * @param {String|Symbol} referenceB The field used to modelB side to reference modelA
+     * @return {void} Return nothing
+     */
+    addReferenceTuple({ referenceA, referenceB, }) {
+      this.references.push([
+        referenceA,
+        referenceB,
+      ]);
     }
 
     /**
@@ -76,23 +94,30 @@ const injectIlorm = ilorm => {
      * @param {String} modelSource The model which reference another model
      * @param {String|Symbol} attributeSource The field of modelSource used to reference modelReference
      * @param {String} modelReference The model to use as referenced
-     * @param {String|Symbol} [attributeReference=Primary] The field of modelReference referenced by attributeSource
      * @return {void} Return nothing
      */
-    static declareRelation({ modelSource, attributeSource, modelReference, attributeReference = Primary, }) {
-      declareRelationSide({
-        modelA: modelSource,
-        referenceA: attributeSource,
-        modelB: modelReference,
-        referenceB: attributeReference,
+    static declareRelation({ modelSource, attributeSource, modelReference, }) {
+      const linearRelation = [
+        {
+          model: modelSource,
+          attribute: attributeSource,
+        }, {
+          model: modelReference,
+          attribute: modelReference,
+        },
+      ].sort((mA, mB) => (
+        mA.model.getName() - mB.model.getName()
+      ));
+
+      const relation = fetchOrInsertRelation({
+        modelA: linearRelation[0].model,
+        modelB: linearRelation[1].model,
         Relation: this,
       });
-      declareRelationSide({
-        modelA: modelReference,
-        referenceA: attributeReference,
-        modelB: modelSource,
-        referenceB: attributeSource,
-        Relation: this,
+
+      relation.addReferenceTuple({
+        referenceA: linearRelation[0].attribute,
+        referenceB: linearRelation[1].attribute,
       });
     }
 

--- a/lib/model/test/model.factory.test.js
+++ b/lib/model/test/model.factory.test.js
@@ -11,6 +11,7 @@ const fakeIlorm = {
     }
   },
   modelsIndex: new Map(),
+  declareModel: () => {},
 };
 
 const fakeConnector = {

--- a/lib/model/test/relation.classFactory.test.js
+++ b/lib/model/test/relation.classFactory.test.js
@@ -7,13 +7,22 @@ const relationClassFactory = require('../relation.classFactory');
 const generateFakeIlorm = fakeReferenceMap => ({ modelsRelationsIndex: fakeReferenceMap });
 
 // Fake model:
-const MODEL_A = 'ModelA';
-const MODEL_B = 'ModelB';
-const MODEL_C = 'ModelC';
-const MODEL_D = 'ModelD';
+const MODEL_A = {
+  getName: () => 'ModelA',
+};
+const MODEL_B = {
+  getName: () => 'ModelB',
+};
+const MODEL_C = {
+  getName: () => 'ModelC',
+};
+const MODEL_D = {
+  getName: () => 'ModelD',
+};
 
 // Fake attribute:
 const ATTRIBUTE_A = Symbol('AttributeA');
+const ATTRIBUTE_B = Symbol('AttributeB');
 
 
 describe('ilorm', () => {
@@ -26,22 +35,22 @@ describe('ilorm', () => {
         Relations.declareRelation({
           modelSource: MODEL_A,
           attributeSource: ATTRIBUTE_A,
-          modelReference: MODEL_B
+          modelReferenced: MODEL_B,
+          attributeReferenced: ATTRIBUTE_B,
         });
 
         expect(referencesMap.get(MODEL_A)).to.be.an.instanceof(Map);
         expect(referencesMap.get(MODEL_A).get(MODEL_B)).to.be.an.instanceof(Relations);
         expect(referencesMap.get(MODEL_A).get(MODEL_B).modelA).to.be.equal(MODEL_A);
         expect(referencesMap.get(MODEL_A).get(MODEL_B).modelB).to.be.equal(MODEL_B);
-        expect(referencesMap.get(MODEL_A).get(MODEL_B).referenceA).to.be.equal(ATTRIBUTE_A);
-        expect(referencesMap.get(MODEL_A).get(MODEL_B).referenceB).to.be.equal(Relations.Primary);
+        expect(referencesMap.get(MODEL_A).get(MODEL_B).references).to.deep.include([ATTRIBUTE_A, ATTRIBUTE_B]);
 
         expect(referencesMap.get(MODEL_B)).to.be.an.instanceof(Map);
         expect(referencesMap.get(MODEL_B).get(MODEL_A)).to.be.an.instanceof(Relations);
-        expect(referencesMap.get(MODEL_B).get(MODEL_A).modelA).to.be.equal(MODEL_B);
-        expect(referencesMap.get(MODEL_B).get(MODEL_A).modelB).to.be.equal(MODEL_A);
-        expect(referencesMap.get(MODEL_B).get(MODEL_A).referenceA).to.be.equal(Relations.Primary);
-        expect(referencesMap.get(MODEL_B).get(MODEL_A).referenceB).to.be.equal(ATTRIBUTE_A);
+        expect(referencesMap.get(MODEL_B).get(MODEL_A).modelA).to.be.equal(MODEL_A);
+        expect(referencesMap.get(MODEL_B).get(MODEL_A).modelB).to.be.equal(MODEL_B);
+        expect(referencesMap.get(MODEL_A).get(MODEL_B).references).to.deep.include([ATTRIBUTE_A, ATTRIBUTE_B]);
+
       });
       it('Should get the relation from the reference map after calling the getRelation', () => {
         const referencesMap = new Map();
@@ -50,28 +59,27 @@ describe('ilorm', () => {
         Relations.declareRelation({
           modelSource: MODEL_A,
           attributeSource: ATTRIBUTE_A,
-          modelReference: MODEL_B
+          modelReferenced: MODEL_B,
+          attributeReferenced: ATTRIBUTE_B,
         });
 
         const relationSideA = Relations.getRelation({
           modelSource: MODEL_B,
-          modelReference: MODEL_A,
+          modelReferenced: MODEL_A,
         });
 
-        expect(relationSideA.modelA).to.be.equal(MODEL_B);
-        expect(relationSideA.modelB).to.be.equal(MODEL_A);
-        expect(relationSideA.referenceA).to.be.equal(Relations.Primary);
-        expect(relationSideA.referenceB).to.be.equal(ATTRIBUTE_A);
+        expect(relationSideA.modelA).to.be.equal(MODEL_A);
+        expect(relationSideA.modelB).to.be.equal(MODEL_B);
+        expect(relationSideA.references).to.deep.include([ATTRIBUTE_A, ATTRIBUTE_B]);
 
         const relationSideB = Relations.getRelation({
           modelSource: MODEL_A,
-          modelReference: MODEL_B,
+          modelReferenced: MODEL_B,
         });
 
         expect(relationSideB.modelA).to.be.equal(MODEL_A);
         expect(relationSideB.modelB).to.be.equal(MODEL_B);
-        expect(relationSideB.referenceA).to.be.equal(ATTRIBUTE_A);
-        expect(relationSideB.referenceB).to.be.equal(Relations.Primary);
+        expect(relationSideB.references).to.deep.include([ATTRIBUTE_A, ATTRIBUTE_B]);
       });
       it('Should throw error if relation does not exists.', () => {
         const referencesMap = new Map();
@@ -80,23 +88,25 @@ describe('ilorm', () => {
         Relations.declareRelation({
           modelSource: MODEL_A,
           attributeSource: ATTRIBUTE_A,
-          modelReference: MODEL_B
+          modelReferenced: MODEL_B,
+          attributeReferenced: ATTRIBUTE_B,
         });
 
         Relations.declareRelation({
           modelSource: MODEL_A,
           attributeSource: ATTRIBUTE_A,
-          modelReference: MODEL_C
+          modelReferenced: MODEL_C,
+          attributeReferenced: ATTRIBUTE_B,
         });
 
         const missingRelation = () => Relations.getRelation({
           modelSource: MODEL_B,
-          modelReference: MODEL_C,
+          modelReferenced: MODEL_C,
         });
 
         const modelNotInRelation = () => Relations.getRelation({
           modelSource: MODEL_D,
-          modelReference: MODEL_C,
+          modelReferenced: MODEL_C,
         });
 
         expect(modelNotInRelation).to.throw(Error, `ModelD does not exists in references map. Could not be linked with ModelC`);


### PR DESCRIPTION
### Path to reference graph;
- [x] Rewamp Relation object to store multiple attributes references
- [x] Work with Field.bindModel to declare reference only when the field have a Model
- [x] Work with ilorm to handle case of reference is a string (could probably wait to the new model to be declared before associate them).
- [x] Add a Field.reference(targetModel, targetField) // or refer to? // to associate a field (in a schema declaration) to another model / field

# Probably, in another PR 
### restrictTo(Model | Query)
- [ ] Way to overload behavior when resolving reference (for handling join in SQL)
- [ ] Dummy approach for handling reference (stream for the win? // Avoid loading too much data).

### way to load a reference from an instance (ex: Model.getLinkedModelQuery() (if 1:n) OR Model.getModel() (if 1:1))
- [ ] POC (need to explore primary value way?)

### Future
- [ ] Explore a way to manage relation between different connector
